### PR TITLE
Feat/install via script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,15 +7,15 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 case $ARCH in
-    x86_64)
-        ARCH="amd64"
-        ;;
-    aarch64|arm64)
-        ARCH="arm64"
-        ;;
-    i386|i686)
-        ARCH="386"
-        ;;
+	x86_64)
+		ARCH="amd64"
+		;;
+	aarch64|arm64)
+		ARCH="arm64"
+		;;
+	i386|i686)
+		ARCH="386"
+		;;
 	*)
 		echo "Unsupported architecture: $ARCH"
 		exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 set -e
 
 # Determine OS and architecture
@@ -9,19 +10,26 @@ case $ARCH in
     x86_64)
         ARCH="amd64"
         ;;
-    aarch64)
+    aarch64|arm64)
         ARCH="arm64"
         ;;
     i386|i686)
         ARCH="386"
         ;;
+	*)
+		echo "Unsupported architecture: $ARCH"
+		exit 1
+		;;
 esac
 
-# Set latest release version
-VERSION=$(curl -s "https://api.github.com/repos/savannahostrowski/gruyere/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/')
+# Check for version argument
+# Otherwise, set latest release version
+if [ -z "$VERSION" ]; then
+	VERSION=$(curl -s "https://api.github.com/repos/savannahostrowski/gruyere/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([0-9.]+)".*/\1/')
+fi
 
 # Construct download URL
-DOWNLOAD_URL="https://github.com/savannahostrowski/gruyere/releases/download/v1.1.5/gruyere_${VERSION}_${OS}_${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/savannahostrowski/gruyere/releases/download/v${VERSION}/gruyere_${VERSION}_${OS}_${ARCH}.tar.gz"
 
 # Create temporary directory
 TMP_DIR=$(mktemp -d)
@@ -29,12 +37,22 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Download and extract
 echo "Downloading gruyere ${VERSION} for ${OS} ${ARCH}..."
-curl -L "$DOWNLOAD_URL" | tar -xz -C "$TMP_DIR"
+curl -L -s "$DOWNLOAD_URL" | tar -xz -C "$TMP_DIR"
 
-# Install
-INSTALL_DIR="/usr/local/bin"
-echo "Installing gruyere to $INSTALL_DIR..."
-sudo mv "$TMP_DIR/gruyere" "$INSTALL_DIR/"
+# Check if directory is writable by the current user
+# If not, use sudo to install
+INSTALL_DIR=${INSTALL_DIR:-/usr/local/bin}
+if [ ! -w "$INSTALL_DIR" ]; then
+	echo "Installing gruyere to $INSTALL_DIR..."
+	sudo mkdir -p "$INSTALL_DIR"
+	sudo mv "$TMP_DIR/gruyere" "$INSTALL_DIR/"
+else
+	echo "Installing gruyere to $INSTALL_DIR..."
+	mkdir -p "$INSTALL_DIR"
+	mv "$TMP_DIR/gruyere" "$INSTALL_DIR/"
+fi
 
 echo "gruyere ${VERSION} has been installed successfully!"
+echo "Be sure that $INSTALL_DIR is in your PATH:"
+printf "\n\texport PATH=\$PATH:%s\n\n" "$INSTALL_DIR"
 echo "You can now use the 'gruyere' command."


### PR DESCRIPTION
I like @Mr-Sunglasses' approach. Tested locally on an M1 Pro Mac with my additional changes. That is:

- get interpreter from path
- add silicon mac arch
- control for "unsupported" arches
- remove hard-coded version
- allow for overriding the install directory and version
- create directory if it doesn't exist
- silence curl output
- only use sudo if it's not writable by the current user
- use printf for posix (sh) instructions on adding the binary to the path

To override the env vars, can run
```bash
λ INSTALL_DIR=~/.local/bin ./install.sh
Downloading gruyere 1.1.5 for darwin arm64...
Installing gruyere to /Users/lance/.local/bin...
gruyere 1.1.5 has been installed successfully!
Be sure that /Users/lance/.local/bin is in your PATH:

        export PATH=$PATH:/Users/lance/.local/bin

You can now use the 'gruyere' command.

λ VERSION=1.1.4 ./install.sh
...

λ INSTALL_DIR=/opt/bin VERSION=1.1.4 ./install.sh
Downloading gruyere 1.1.4 for darwin arm64...
Installing gruyere to /opt/bin...
Password:
...
```

I don't normally edit other contributors' PRs on repos I don't own so the process is lost on me (git is hard haha.) I don't need direct git attribution if you just wanna copy and paste things [xkcd style](https://m.xkcd.com/1597/) (or could create co-authoring alternately.)
